### PR TITLE
Add `is_imported`

### DIFF
--- a/generalimport/__init__.py
+++ b/generalimport/__init__.py
@@ -1,7 +1,7 @@
 
 from generalimport.generalimport_bottom import get_installed_modules_names, module_is_installed, import_module, module_name_is_namespace, module_is_namespace, spec_is_namespace, _get_previous_frame_filename, _get_top_name, _get_scope_from_filename, get_spec, fake_module_check
 from generalimport.exception import MissingOptionalDependency
-from generalimport.fake_module import FakeModule
+from generalimport.fake_module import FakeModule, import_checkgit 
 from generalimport.general_importer import GeneralImporter
 from generalimport.import_catcher import ImportCatcher
 from generalimport.top import generalimport, get_importer, reset_generalimport

--- a/generalimport/__init__.py
+++ b/generalimport/__init__.py
@@ -1,7 +1,7 @@
 
 from generalimport.generalimport_bottom import get_installed_modules_names, module_is_installed, import_module, module_name_is_namespace, module_is_namespace, spec_is_namespace, _get_previous_frame_filename, _get_top_name, _get_scope_from_filename, get_spec, fake_module_check
 from generalimport.exception import MissingOptionalDependency
-from generalimport.fake_module import FakeModule, import_check
+from generalimport.fake_module import FakeModule, is_imported
 from generalimport.general_importer import GeneralImporter
 from generalimport.import_catcher import ImportCatcher
 from generalimport.top import generalimport, get_importer, reset_generalimport

--- a/generalimport/__init__.py
+++ b/generalimport/__init__.py
@@ -1,7 +1,7 @@
 
 from generalimport.generalimport_bottom import get_installed_modules_names, module_is_installed, import_module, module_name_is_namespace, module_is_namespace, spec_is_namespace, _get_previous_frame_filename, _get_top_name, _get_scope_from_filename, get_spec, fake_module_check
 from generalimport.exception import MissingOptionalDependency
-from generalimport.fake_module import FakeModule, import_checkgit 
+from generalimport.fake_module import FakeModule, import_check
 from generalimport.general_importer import GeneralImporter
 from generalimport.import_catcher import ImportCatcher
 from generalimport.top import generalimport, get_importer, reset_generalimport

--- a/generalimport/fake_module.py
+++ b/generalimport/fake_module.py
@@ -82,21 +82,14 @@ class FakeModule:
         "__bases__", "__class__", "__dict__", "__doc__", "__module__", "__name__", "__qualname__", "__all__", "__slots__",
     )
 
-
+#
 def import_check(module_name: str) -> bool:
     """
     Returns True if the module was actually imported, False, if generalimport mocked it.
     """
-    module = sys.modules.get(module_name)
     try:
-        if module and not module.__fake_module__:
-            # It should never reach here because `__fake_module__` should trigger a MissingOptionalDependency
-            # but let's keep it to be safe
-            return True
-    except AttributeError as exc2:
-        # __fake_module__ is missing: real module
-        return True
+        return isinstance(sys.modules.get(module_name), FakeModule)
     except MissingOptionalDependency as exc:
-        # __fake_module__ raises MissingOptionalDependency: fake module
-        return False
+        # isinstance() raises MissingOptionalDependency: fake module
+        pass
     return False

--- a/generalimport/fake_module.py
+++ b/generalimport/fake_module.py
@@ -83,7 +83,7 @@ class FakeModule:
     )
 
 
-def import_check(module_name: str) -> bool:
+def is_imported(module_name: str) -> bool:
     """
     Returns True if the module was actually imported, False, if generalimport mocked it.
     """

--- a/generalimport/fake_module.py
+++ b/generalimport/fake_module.py
@@ -14,7 +14,7 @@ class FakeModule:
         self.__name__ = spec.name
         self.__loader__ = spec.loader
         self.__spec__ = spec
-        self.__fake_module__ = True  # To bypass isinstance()
+        self.__fake_module__ = True  # Should not be needed, but let's keep it for safety?
 
     def error_func(self, *args, **kwargs):
         name = f"'{self.name}'" if hasattr(self, "name") else ""  # For __class_getitem__

--- a/generalimport/fake_module.py
+++ b/generalimport/fake_module.py
@@ -87,8 +87,9 @@ def is_imported(module_name: str) -> bool:
     """
     Returns True if the module was actually imported, False, if generalimport mocked it.
     """
+    module = sys.modules.get(module_name)
     try:
-        return not isinstance(sys.modules.get(module_name), FakeModule)
+        return bool(module and not isinstance(module, FakeModule))
     except MissingOptionalDependency as exc:
         # isinstance() raises MissingOptionalDependency: fake module
         pass

--- a/generalimport/fake_module.py
+++ b/generalimport/fake_module.py
@@ -82,7 +82,7 @@ class FakeModule:
         "__bases__", "__class__", "__dict__", "__doc__", "__module__", "__name__", "__qualname__", "__all__", "__slots__",
     )
 
-#
+
 def import_check(module_name: str) -> bool:
     """
     Returns True if the module was actually imported, False, if generalimport mocked it.

--- a/generalimport/fake_module.py
+++ b/generalimport/fake_module.py
@@ -88,7 +88,7 @@ def is_imported(module_name: str) -> bool:
     Returns True if the module was actually imported, False, if generalimport mocked it.
     """
     try:
-        return isinstance(sys.modules.get(module_name), FakeModule)
+        return not isinstance(sys.modules.get(module_name), FakeModule)
     except MissingOptionalDependency as exc:
         # isinstance() raises MissingOptionalDependency: fake module
         pass

--- a/generalimport/fake_module.py
+++ b/generalimport/fake_module.py
@@ -1,3 +1,4 @@
+import sys
 from generalimport import MissingOptionalDependency
 
 
@@ -79,3 +80,13 @@ class FakeModule:
         # Info
         "__bases__", "__class__", "__dict__", "__doc__", "__module__", "__name__", "__qualname__", "__all__", "__slots__",
     )
+
+
+def import_check(package_name: str) -> bool:
+    """
+    Returns True if the module was actually imported, False, if generalimport mocked it.
+    """
+    package = sys.modules.get(package_name)
+    if not package or isinstance(package, FakeModule):
+        return False
+    return True

--- a/generalimport/test/test_generalimport.py
+++ b/generalimport/test/test_generalimport.py
@@ -21,6 +21,7 @@ class Test(ImportTestCase):
     
     def test_package_is_imported(self):
         self.assertEqual(True, is_imported("generalimport"))
+        self.assertEqual(False, is_imported("setuptools"))
         self.assertEqual(False, is_imported("doesntexist"))
 
     def test_MissingOptionalDependency(self):

--- a/generalimport/test/test_generalimport.py
+++ b/generalimport/test/test_generalimport.py
@@ -18,6 +18,10 @@ class Test(ImportTestCase):
         self.assertEqual(True, module_is_installed("generalimport"))
         self.assertEqual(True, module_is_installed("setuptools"))
         self.assertEqual(False, module_is_installed("doesntexist"))
+    
+    def test_package_is_imported(self):
+        self.assertEqual(True, is_imported("generalimport"))
+        self.assertEqual(False, is_imported("doesntexist"))
 
     def test_MissingOptionalDependency(self):
         self.assertEqual("foo", MissingOptionalDependency("foo").msg)


### PR DESCRIPTION
Adds a small function that can be used to check whether a specific package has been mocked by `generalimport` or not without triggering a `MissingDependencyException`. 

I'm personally using this with `sqlalchemy`, where the library needs to generate some base classes at import time. With this function I can decide to generate them only if `sqlalchemy` was actually imported.