### PR TITLE
Custom error messages for missing dependencies

### DIFF
--- a/generalimport/fake_module.py
+++ b/generalimport/fake_module.py
@@ -18,7 +18,7 @@ class FakeModule:
 
     def error_func(self, *args, **kwargs):
         name = f"'{self.name}'" if hasattr(self, "name") else ""  # For __class_getitem__
-        message = f" {self.message}" if hasattr(self, "message") else ""  # For __class_getitem__
+        message = f" {self.message}" if getattr(self, "message", None) else ""  # For __class_getitem__
         raise MissingOptionalDependency(
             f"Optional dependency {name} was used but it isn't installed.{message}"
         )

--- a/generalimport/fake_module.py
+++ b/generalimport/fake_module.py
@@ -9,17 +9,20 @@ class FakeModule:
     __path__ = []
     __args__ = []
 
-    def __init__(self, spec):
+    def __init__(self, spec, message: str):
         self.name = spec.name
+        self.message = message
 
         self.__name__ = spec.name
         self.__loader__ = spec.loader
         self.__spec__ = spec
-        self.__fake_module__ = True  # Should not be needed, but let's keep it for safety?
 
     def error_func(self, *args, **kwargs):
         name = f"'{self.name}'" if hasattr(self, "name") else ""  # For __class_getitem__
-        raise MissingOptionalDependency(f"Optional dependency {name} was used but it isn't installed.")
+        message = f" {self.message}" if hasattr(self, "message") else ""  # For __class_getitem__
+        raise MissingOptionalDependency(
+            f"Optional dependency {name} was used but it isn't installed.{message}"
+        )
 
     def __getattr__(self, item):
         if item in self.non_called_dunders:

--- a/generalimport/fake_module.py
+++ b/generalimport/fake_module.py
@@ -7,7 +7,6 @@ class FakeModule:
         Raises a ModuleNotFoundError when used in any way.
         Unhandled use-cases: https://github.com/ManderaGeneral/generalimport/issues?q=is%3Aissue+is%3Aopen+label%3Aunhandled """
     __path__ = []
-    __args__ = []
 
     def __init__(self, spec, message: str):
         self.name = spec.name

--- a/generalimport/fake_module.py
+++ b/generalimport/fake_module.py
@@ -7,6 +7,7 @@ class FakeModule:
         Raises a ModuleNotFoundError when used in any way.
         Unhandled use-cases: https://github.com/ManderaGeneral/generalimport/issues?q=is%3Aissue+is%3Aopen+label%3Aunhandled """
     __path__ = []
+    __args__ = []
 
     def __init__(self, spec):
         self.name = spec.name

--- a/generalimport/general_importer.py
+++ b/generalimport/general_importer.py
@@ -15,6 +15,7 @@ class GeneralImporter:
 
     def __init__(self):
         self.catchers = []
+        self.messages = {}
 
         self._singleton()
         self._skip_fullname = None
@@ -45,12 +46,10 @@ class GeneralImporter:
         return self._handle_relay(fullname=fullname, spec=spec)
 
     def create_module(self, spec):
-        return FakeModule(spec=spec)
+        return FakeModule(spec=spec, message=self.messages.get(spec.name, None))
 
     def exec_module(self, module):
         pass
-
-
 
     def _singleton(self):
         assert self.singleton_instance is None

--- a/generalimport/import_catcher.py
+++ b/generalimport/import_catcher.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 from logging import getLogger
 
 from generalimport import _get_previous_frame_filename, _get_top_name, _get_scope_from_filename
@@ -6,7 +8,7 @@ from generalimport import _get_previous_frame_filename, _get_top_name, _get_scop
 class ImportCatcher:
     WILDCARD = "*"
 
-    def __init__(self, *names):
+    def __init__(self, *names: Iterable[str]):
         self.names = set(names)
         self.added_names = set()
         self.added_fullnames = set()
@@ -25,8 +27,6 @@ class ImportCatcher:
 
         self._store_handled_name(fullname=fullname)
         return True
-
-
 
     @staticmethod
     def _get_scope():

--- a/generalimport/test/test_generalimport.py
+++ b/generalimport/test/test_generalimport.py
@@ -183,12 +183,24 @@ class Test(ImportTestCase):
         self.assertIn("test_generalimport.py", catcher.latest_scope_filename)
 
     def test_custom_error_message(self):
-        generalimport(("hi", "Get 'hi' with 'pip install python-hi'."))
+        generalimport(
+            ("hi", "Get 'hi' with 'pip install python-hi'."),
+            "hello"
+        )
         import hi
 
         with self.assertRaises(MissingOptionalDependency) as missing_dep_error:
             hi.greet()
         self.assertEqual(
             "Optional dependency 'hi' was used but it isn't installed. Get 'hi' with 'pip install python-hi'.",
+            str(missing_dep_error.exception)
+        )
+
+        import hello
+
+        with self.assertRaises(MissingOptionalDependency) as missing_dep_error:
+            hello.greet()
+        self.assertEqual(
+            "Optional dependency 'hello' was used but it isn't installed.",
             str(missing_dep_error.exception)
         )

--- a/generalimport/test/test_generalimport.py
+++ b/generalimport/test/test_generalimport.py
@@ -182,27 +182,13 @@ class Test(ImportTestCase):
         self.assertIs(True, fake_module_check(hi, error=False))
         self.assertIn("test_generalimport.py", catcher.latest_scope_filename)
 
+    def test_custom_error_message(self):
+        generalimport(("hi", "Get 'hi' with 'pip install python-hi'."))
+        import hi
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        with self.assertRaises(MissingOptionalDependency) as missing_dep_error:
+            hi.greet()
+        self.assertEqual(
+            "Optional dependency 'hi' was used but it isn't installed. Get 'hi' with 'pip install python-hi'.",
+            str(missing_dep_error.exception)
+        )

--- a/generalimport/top.py
+++ b/generalimport/top.py
@@ -1,3 +1,5 @@
+from typing import List, Union, Tuple
+
 import sys
 
 from generalimport import GeneralImporter, ImportCatcher
@@ -11,12 +13,15 @@ def get_importer():
     """ Return existing or new GeneralImporter instance. """
     return GeneralImporter.singleton_instance or GeneralImporter()
 
-def generalimport(*names):
+def generalimport(*name_message_pairs: List[Union[str, Tuple[str, str]]]):
     """ Adds names to a new ImportCatcher instance.
         Creates GeneralImporter instance if it doesn't exist. """
     # print(get_previous_frame_filename())
+    names = [n[0] if isinstance(n, Tuple) else n for n in name_message_pairs]
+    messages = {m[0]: m[1] for m in name_message_pairs if isinstance(m, Tuple)}
     _assert_no_dots(names=names)
     catcher = ImportCatcher(*names)
+    get_importer().messages.update(messages)
     get_importer().catchers.append(catcher)
     return catcher
 


### PR DESCRIPTION
Fixes https://github.com/ManderaGeneral/generalimport/issues/32. Backwards compatible.

Added unit test. Also removes a stray line that was probably in the `is_imported` PR: sorry for that! :see_no_evil: 

Usecase:
```python
generalimport(("hi", "Get 'hi' with 'pip install python-hi'."))
import hi

hi.greet()
# MissingOptionalDependency: Optional dependency 'hi' was used but it isn't installed. Get 'hi' with 'pip install python-hi'.
```